### PR TITLE
Codecs for explicitely sized ints, exported lib for skeletons

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,10 @@ SUBDIRS = 				\
 	doc asn1c
 
 docsdir = $(datadir)/doc/asn1c
+pkgconfigdir = $(libdir)/pkgconfig
 
 docs_DATA = README.md FAQ COPYING ChangeLog BUGS TODO
+pkgconfig_DATA = asn1c.pc
 
-EXTRA_DIST = asn1c.spec.in README.md FAQ BUGS MANIFEST tests/
+EXTRA_DIST = asn1c.spec.in asn1c.pc.in README.md FAQ BUGS MANIFEST tests/
 CLEANFILES = asn1c.spec

--- a/asn1c.pc.in
+++ b/asn1c.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: asn1c
+Version: @PACKAGE_VERSION@
+Description: The ASN.1 Compiler
+URL: https://github.com/vlm/asn1c
+Libs: -L${libdir} -lasn1cskeletons
+Cflags: -I${includedir}

--- a/configure.ac
+++ b/configure.ac
@@ -7,10 +7,13 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AM_MAINTAINER_MODE
 
+AM_PROG_AR
+
 AM_PROG_LIBTOOL
 
 dnl Checks for programs.
 AC_PROG_CC
+AM_PROG_CC_C_O
 AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_LN_S
@@ -113,6 +116,7 @@ examples/Makefile			\
 asn1c/Makefile				\
 doc/Makefile				\
 asn1c.spec				\
+asn1c.pc				\
 Makefile				\
 )
 

--- a/skeletons/INTEGER.h
+++ b/skeletons/INTEGER.h
@@ -75,6 +75,24 @@ enum asn_strtol_result_e asn_strtol(const char *str, const char *end, long *l);
  */
 const asn_INTEGER_enum_map_t *INTEGER_map_value2enum(asn_INTEGER_specifics_t *specs, long value);
 
+#include <stdint.h>
+
+int asn_INTEGER_to_int64 (const INTEGER_t *st, int64_t *pI64);
+int asn_INTEGER_to_int32 (const INTEGER_t *st, int32_t *pI32);
+int asn_INTEGER_to_int16 (const INTEGER_t *st, int16_t *pI16);
+int asn_INTEGER_to_int8  (const INTEGER_t *st, int8_t *pI8);
+int asn_INTEGER_to_uint32 (const INTEGER_t *st, uint32_t *pU32);
+int asn_INTEGER_to_uint16 (const INTEGER_t *st, uint16_t *pU16);
+int asn_INTEGER_to_uint8  (const INTEGER_t *st, uint8_t *pU8);
+
+int asn_int64_to_INTEGER (INTEGER_t *st, int64_t v);
+int asn_int32_to_INTEGER (INTEGER_t *st, int32_t v);
+int asn_int16_to_INTEGER (INTEGER_t *st, int16_t v);
+int asn_int8_to_INTEGER  (INTEGER_t *st, int8_t v);
+int asn_uint32_to_INTEGER (INTEGER_t *st, uint32_t v);
+int asn_uint16_to_INTEGER (INTEGER_t *st, uint16_t v);
+int asn_uint8_to_INTEGER  (INTEGER_t *st, uint8_t v);
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/Makefile.am
+++ b/skeletons/Makefile.am
@@ -18,7 +18,7 @@ uninstall-local:
 	-@echo -n " "
 	-rm -f -r $(DESTDIR)$(pkgdatadir)
 
-check_LTLIBRARIES = libasn1cskeletons.la
+lib_LTLIBRARIES = libasn1cskeletons.la
 
 libasn1cskeletons_la_CFLAGS = $(TESTSUITE_CFLAGS)
 libasn1cskeletons_la_SOURCES = 				\


### PR DESCRIPTION
Change-Id: I34b77f2b464624b871c6fb469bd4d43618b33629
